### PR TITLE
Add rules key to meetio sublime-theme

### DIFF
--- a/Meetio.sublime-theme
+++ b/Meetio.sublime-theme
@@ -166,5 +166,6 @@
         "vscUntracked": "var(--greenish)",
         "vscDeleted": "var(--redish)",
         "vscMissing": "var(--orangish)"
-    }
+    },
+    "rules": []
 }


### PR DESCRIPTION
Fixes
```
Errors parsing theme:
  must be a vector or a map with a "rules" key in Packages\Meetio\Meetio.sublime-theme:1:1
```

